### PR TITLE
Fix dialog title on new file creation

### DIFF
--- a/src/main/resources/io/j99/idea/vue/localization/strings.properties
+++ b/src/main/resources/io/j99/idea/vue/localization/strings.properties
@@ -10,7 +10,7 @@ vue.editor.colorsettingspage.value=Value
 #action
 newfile.command.name=Vue File
 newfile.dialog.prompt=Create a new Vue file
-newfile.dialog.title=Create Lua script
+newfile.dialog.title=Create Vue File
 newfile.menu.action.description=Create a new Vue file
 newfile.menu.action.text=New Vue File
 


### PR DESCRIPTION
Fixes the new file dialog reading 'new Lua file' when creating a new .vue file.
